### PR TITLE
Fixed Logo and Title clipping into status bar

### DIFF
--- a/app/src/main/java/com/r3bl/stayawake/MainActivity.kt
+++ b/app/src/main/java/com/r3bl/stayawake/MainActivity.kt
@@ -76,6 +76,8 @@ class MainActivity : AppCompatActivity() {
     //showAppIconInActionBar();
     //hideStatusBar();
 
+    updateTitlePaddingStatusBar()
+
     loadAndApplyFonts()
     formatMessages()
 
@@ -169,6 +171,32 @@ class MainActivity : AppCompatActivity() {
     }
   }
 
+  // Updates app_title top padding, so that the title is displayed in a nice position
+  // relative to the status bar
+  private fun updateTitlePaddingStatusBar() {
+    var newHeight :Int = getStatusBarHeight()
+    // If we could not get the actual value, default to 72 pixels to minimize messing up the layout
+    if (newHeight == 0) {
+      newHeight = 72
+    }
+    app_title.setPadding(
+            app_title.paddingLeft,
+            newHeight,
+            app_title.paddingRight,
+            app_title.paddingBottom)
+  }
+
+  // Returns status bar height in pixels
+  // Taken from https://stackoverflow.com/questions/3407256/height-of-status-bar-in-android
+  private fun getStatusBarHeight(): Int {
+    var result = 0
+    val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
+    if (resourceId > 0) {
+      result = resources.getDimensionPixelSize(resourceId)
+    }
+    return result
+  }
+  
   private fun hideStatusBar() {
     val decorView = window.decorView
     // Hide the status bar.

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,7 @@
       style="@style/AppContainerPadding">
 
     <LinearLayout
+        android:id="@+id/app_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,7 +37,10 @@
   which is an icon and a text
    -->
   <style name="AppTitle">
+    <!--
+    Top padding is set automatically according to status bar height
     <item name="android:paddingTop">25dp</item>
+    -->
     <item name="android:paddingBottom">25dp</item>
   </style>
 


### PR DESCRIPTION
Hi,
maybe you remember me from about a week ago, we had a little talk about this app under my Google Play review. Thank you for the changes you made, I think they made the app much better :)

I noticed one more thing that was buggy on my phone:
https://drive.google.com/file/d/1PQq-abI-49iwPVivDFgnR0L5Dtu9qsb6/view?usp=sharing
and I tried to fix it myself in a way that would work nicely on every device. I think I did OK, it looks good with my oversized status bar and when I flip my phone to horizontal position, the status bar gets normaly-sized again, but the padding I added is recomputed, so it still looks nice.
After patch:
(vertical, big status bar)
https://drive.google.com/file/d/1vfDlXwP2-ERL3SDRDMkk79cuyQ0JYKDn/view?usp=sharing
(horizontal, normal status bar)
https://drive.google.com/file/d/1SwhwXFebWv-4lStwPQeH6oOhC1RscCk3/view?usp=sharing

I mainly wanted to learn a bit about github and android development, since I never did anything like this before. So I will understand if you dont accept this commit, if you dont like it for some reason. But it fixes the bug for me, so I would love to see this getting used in the app :)